### PR TITLE
[chore] jcenterのMavenリポジトリを削除

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        jcenter() // Warning: this repository is going to shut down soon
     }
 }
 rootProject.name = "Android Engineer CodeCheck"


### PR DESCRIPTION
- jcenterは読み取り専用になっているため、Mavenリポジトリとして含めない方が良い