### PR TITLE
[chore] パッケージ名のアンダースコアを除去

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 android {
-  namespace 'jp.co.yumemi.android.code_check'
+  namespace 'jp.co.yumemi.android.codecheck'
   compileSdk 33
 
   defaultConfig {

--- a/app/src/androidTest/kotlin/jp/co/yumemi/android/codecheck/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/jp/co/yumemi/android/codecheck/ExampleInstrumentedTest.kt
@@ -1,4 +1,4 @@
-package jp.co.yumemi.android.code_check
+package jp.co.yumemi.android.codecheck
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:theme="@style/Theme.AndroidEngineerCodeCheck"
         android:fullBackupContent="@xml/backup_descriptor">
         <activity
-            android:name="jp.co.yumemi.android.code_check.TopActivity"
+            android:name="jp.co.yumemi.android.codecheck.TopActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/OneFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/OneFragment.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2021 YUMEMI Inc. All rights reserved.
  */
-package jp.co.yumemi.android.code_check
+package jp.co.yumemi.android.codecheck
 
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -16,7 +16,7 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import jp.co.yumemi.android.code_check.databinding.FragmentOneBinding
+import jp.co.yumemi.android.codecheck.databinding.FragmentOneBinding
 
 class OneFragment : Fragment(R.layout.fragment_one) {
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/OneViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/OneViewModel.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2021 YUMEMI Inc. All rights reserved.
  */
-package jp.co.yumemi.android.code_check
+package jp.co.yumemi.android.codecheck
 
 import android.content.Context
 import android.os.Parcelable

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/TwoFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/TwoFragment.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2021 YUMEMI Inc. All rights reserved.
  */
-package jp.co.yumemi.android.code_check
+package jp.co.yumemi.android.codecheck
 
 import android.os.Bundle
 import android.util.Log
@@ -9,8 +9,8 @@ import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import coil.load
-import jp.co.yumemi.android.code_check.TopActivity.Companion.lastSearchDate
-import jp.co.yumemi.android.code_check.databinding.FragmentTwoBinding
+import jp.co.yumemi.android.codecheck.TopActivity.Companion.lastSearchDate
+import jp.co.yumemi.android.codecheck.databinding.FragmentTwoBinding
 
 class TwoFragment : Fragment(R.layout.fragment_two) {
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/topActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/topActivity.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2021 YUMEMI Inc. All rights reserved.
  */
-package jp.co.yumemi.android.code_check
+package jp.co.yumemi.android.codecheck
 
 import androidx.appcompat.app.AppCompatActivity
 import java.util.Date

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -7,7 +7,7 @@
 
     <fragment
         android:id="@+id/oneFragment"
-        android:name="jp.co.yumemi.android.code_check.OneFragment"
+        android:name="jp.co.yumemi.android.codecheck.OneFragment"
         android:label="@string/app_name"
         tools:layout="@layout/fragment_one">
         <action
@@ -17,12 +17,12 @@
 
     <fragment
         android:id="@+id/twoFragment"
-        android:name="jp.co.yumemi.android.code_check.TwoFragment"
+        android:name="jp.co.yumemi.android.codecheck.TwoFragment"
         android:label="@string/app_name"
         tools:layout="@layout/fragment_two">
         <argument
             android:name="item"
-            app:argType="jp.co.yumemi.android.code_check.item" />
+            app:argType="jp.co.yumemi.android.codecheck.item" />
     </fragment>
 
 </navigation>

--- a/app/src/test/kotlin/jp/co/yumemi/android/codecheck/ExampleUnitTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/codecheck/ExampleUnitTest.kt
@@ -1,4 +1,4 @@
-package jp.co.yumemi.android.code_check
+package jp.co.yumemi.android.codecheck
 
 import org.junit.Assert.assertEquals
 import org.junit.Test


### PR DESCRIPTION
## 概要

パッケージの名前にアンダースコア `_` を含めるべきではないため、パッケージ名を修正。

## スクリーンショット（あれば）

Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
