### PR TITLE
[build] jetifierを無効化

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
+android.enableJetifier=false
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 # configure cache


### PR DESCRIPTION
## 概要

レガシーサポートの依存関係は存在しないため、jetifierを無効化。

## スクリーンショット（あれば）

Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
