### PR TITLE
[refactor] SearchRepositoryDiffUtilProviderのリフォーマット

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/feature/search/SearchRepositoryDiffUtilProvider.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/feature/search/SearchRepositoryDiffUtilProvider.kt
@@ -9,11 +9,17 @@ import jp.co.yumemi.android.codecheck.Repository
 class SearchRepositoryDiffUtilProvider {
   fun provide(): DiffUtil.ItemCallback<Repository> {
     return object : DiffUtil.ItemCallback<Repository>() {
-      override fun areItemsTheSame(oldItem: Repository, newItem: Repository): Boolean {
+      override fun areItemsTheSame(
+        oldItem: Repository,
+        newItem: Repository,
+      ): Boolean {
         return oldItem.name == newItem.name
       }
 
-      override fun areContentsTheSame(oldItem: Repository, newItem: Repository): Boolean {
+      override fun areContentsTheSame(
+        oldItem: Repository,
+        newItem: Repository,
+      ): Boolean {
         return oldItem == newItem
       }
     }


### PR DESCRIPTION
## 概要

SearchRepositoryDiffUtilProviderが80文字を超えているので温かみのある手作業でリフォーマット

## スクリーンショット（あれば）

Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
